### PR TITLE
Fixed the issue of new Oauth tab not closing automatically in some browsers

### DIFF
--- a/server/plugin/oAuth.go
+++ b/server/plugin/oAuth.go
@@ -261,6 +261,7 @@ func (p *Plugin) CloseBrowserWindowWithHTTPResponse(w http.ResponseWriter) {
 	<html>
 		<head>
 			<script>
+				window.open('','_parent','');
 				window.close();
 			</script>
 		</head>


### PR DESCRIPTION
#### Summary
Fixed the issue of new Oauth tab not closing automatically in some browsers

#### Reference
https://stackoverflow.com/questions/31981848/window-close-not-working-in-firefox
